### PR TITLE
fix: readme installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,15 @@
     <h1>Official pyannoteAI Python SDK </h1>
 </div>
 
-
 ## Installation
 
 ```bash
-$ pip install pyannoteai.sdk
+$ pip install pyannoteai-sdk
 ```
 
 Then head over to [`dashboard.pyannote.ai`](https://dashboard.pyannote.ai) and create an API key.
 
-## Speaker diarization 
+## Speaker diarization
 
 ```python
 # instantiate client


### PR DESCRIPTION
## Description
I found an inconsistency between the `README.md` install instruction and the one provided in https://pypi.org/project/pyannoteai-sdk/.

<img width="458" height="254" alt="image" src="https://github.com/user-attachments/assets/daec9615-42d4-4c6e-a0e6-7a4a0eaccc95" />

### Disclaimer
I 'm not familiar with Python or `pip`. So feel free to completely discard this PR if it doesn't make sense!